### PR TITLE
Kill ability to run async acts

### DIFF
--- a/src/ch/index.js
+++ b/src/ch/index.js
@@ -18,14 +18,9 @@ module.exports = function() {
       if (actsQueue.length > 0) callCb()
     },
 
-    act: function(act, async) {
+    act: function(act) {
       actsQueue.push.apply(actsQueue, [].concat(act))
-
-      if (async) {
-        setTimeout(callCb, 0)
-      } else {
-        callCb()
-      }
+      callCb()
     }
   }
 }

--- a/src/ch/test.js
+++ b/src/ch/test.js
@@ -58,31 +58,5 @@ describe('ch', function() {
       actsCh.take(spy)
       assert(spy.calledOnce)
     })
-
-    describe('async act', function() {
-      it('resolves the promise with array of consequentially putted acts', function(done) {
-        var actA = function() {}
-        var actB = function() {}
-        actsCh.take(function(nextActs) {
-          assert(nextActs[0] === actA)
-          assert(nextActs[1] === actB)
-          done()
-        })
-
-        actsCh.act(actA, true)
-        actsCh.act(actB, true)
-      })
-
-      it('resolves acts just once', function(done) {
-        actsCh.take(function() {
-          actsCh.take(assert.bind(false))
-          setTimeout(done, 1)
-        })
-
-        for (var i = 0; i < 10; i++) {
-          actsCh.act(function() {}, true)
-        }
-      })
-    })
   })
 })

--- a/src/loop/index.js
+++ b/src/loop/index.js
@@ -6,7 +6,7 @@ module.exports = function(ch, initialState, render) {
       }, state)
 
       render(nextState, state)
-      setTimeout(renderLoop.bind(null,nextState), 0)
+      setTimeout(renderLoop.bind(null, nextState), 0)
     })
   }
 

--- a/src/loop/test.js
+++ b/src/loop/test.js
@@ -15,132 +15,64 @@ describe('loop', function() {
     assert(render.calledWithExactly(initialState, null))
   })
 
-  context('when acts are sync', function() {
-    it('passes state modified by acts', function(done) {
-      var render = sinon.spy()
-      loop(actsCh, [], render)
+  it('passes state modified by acts', function(done) {
+    var render = sinon.spy()
+    loop(actsCh, [], render)
 
-      actsCh.act(function(state) {
-        return state.concat(1)
-      })
-
-      actsCh.act(function(state) {
-        return state.concat(2)
-      })
-
-      setTimeout(function() {
-        assert(render.calledWith([1, 2]))
-        done()
-      }, 25)
+    actsCh.act(function(state) {
+      return state.concat(1)
     })
 
-    it('passes next state once it is ready', function(done) {
-      var render = sinon.spy()
-      loop(actsCh, [], render)
-
-      actsCh.act(function(state) {
-        return state.concat(1)
-      })
-
-      actsCh.act(function(state) {
-        return state.concat(2)
-      })
-
-      assert(render.calledWith([1]))
-      assert(render.calledTwice)
-
-      setTimeout(function() {
-        assert(render.calledWith([1, 2]))
-        assert(render.calledThrice)
-        done()
-      }, 25)
+    actsCh.act(function(state) {
+      return state.concat(2)
     })
 
-    it('passes previous state', function(done) {
-      var render = sinon.spy()
-      var states = []
-      loop(actsCh, [], function(state, prevState) {
-        states.push([state, prevState])
-      })
-
-      actsCh.act(function(state) {
-        return state.concat(1)
-      })
-
-      actsCh.act(function(state) {
-        return state.concat(2)
-      })
-
-      setTimeout(function() {
-        assert(states[1][1] === states[0][0])
-        done()
-      }, 25)
-    })
+    setTimeout(function() {
+      assert(render.calledWith([1, 2]))
+      done()
+    }, 25)
   })
 
-  context('when acts are async', function() {
-    it('passes state modified by acts', function(done) {
-      var render = sinon.spy()
-      loop(actsCh, [], render)
+  it('passes next state once it is ready', function(done) {
+    var render = sinon.spy()
+    loop(actsCh, [], render)
 
-      actsCh.act(function(state) {
-        return state.concat(1)
-      }, true)
-
-      actsCh.act(function(state) {
-        return state.concat(2)
-      }, true)
-
-      setTimeout(function() {
-        assert(render.calledWith([1, 2]))
-        done()
-      }, 25)
+    actsCh.act(function(state) {
+      return state.concat(1)
     })
 
-    it('passes next state once it is ready', function(done) {
-      var render = sinon.spy()
-      loop(actsCh, [], render)
-
-      actsCh.act(function(state) {
-        return state.concat(1)
-      }, true)
-
-      setTimeout(function() {
-        actsCh.act(function(state) {
-          return state.concat(2)
-        }, true)
-
-        setTimeout(function() {
-          assert(render.calledWith([1]))
-          assert(render.calledWith([1, 2]))
-          done()
-        }, 25)
-      }, 25)
-
-      assert(render.calledOnce)
+    actsCh.act(function(state) {
+      return state.concat(2)
     })
 
-    it('passes previous state', function(done) {
-      var render = sinon.spy()
-      var states = []
-      loop(actsCh, [], function(state, prevState) {
-        states.push([state, prevState])
-      })
+    assert(render.calledWith([1]))
+    assert(render.calledTwice)
 
-      actsCh.act(function(state) {
-        return state.concat(1)
-      }, true)
+    setTimeout(function() {
+      assert(render.calledWith([1, 2]))
+      assert(render.calledThrice)
+      done()
+    }, 25)
+  })
 
-      setTimeout(function() {
-        actsCh.act(function(state) {
-          return state.concat(2)
-        }, true)
-
-        setTimeout(function() {
-          assert(states[1][1] === states[0][0])
-          done()
-        }, 25)
-      }, 25)
+  it('passes previous state', function(done) {
+    var render = sinon.spy()
+    var states = []
+    loop(actsCh, [], function(state, prevState) {
+      states.push([state, prevState])
     })
+
+    actsCh.act(function(state) {
+      return state.concat(1)
+    })
+
+    actsCh.act(function(state) {
+      return state.concat(2)
+    })
+
+    setTimeout(function() {
+      assert(states[1][1] === states[0][0])
+      done()
+    }, 25)
   })
 })

--- a/test.js
+++ b/test.js
@@ -12,7 +12,8 @@ var enso = require('./')
 
 describe('enso', function() {
   it('exports loop & act functions', function() {
-    assert(enso.loop typeof 'function')
+    assert(typeof enso.loop == 'function')
+    assert(typeof enso.act == 'function')
   })
 
   it('wraps channel & loop', function(done) {


### PR DESCRIPTION
The functionality is redundant and could be easily implemented using `setTimeout`.