### PR TITLE
Don't use setTimeout

### DIFF
--- a/src/loop/index.js
+++ b/src/loop/index.js
@@ -6,7 +6,7 @@ module.exports = function(take, initialState, render) {
       }, state)
 
       render(nextState, state)
-      setTimeout(renderLoop.bind(null, nextState))
+      renderLoop(nextState)
     })
   }
 

--- a/src/loop/test.js
+++ b/src/loop/test.js
@@ -15,7 +15,7 @@ describe('loop', function() {
     assert(render.calledWithExactly(initialState, null))
   })
 
-  it('passes state modified by acts', function(done) {
+  it('passes state modified by acts', function() {
     var render = sinon.spy()
     loop(actsCh.take, [], render)
 
@@ -27,13 +27,10 @@ describe('loop', function() {
       return state.concat(2)
     })
 
-    setTimeout(function() {
-      assert(render.calledWith([1, 2]))
-      done()
-    }, 25)
+    assert(render.calledWith([1, 2]))
   })
 
-  it('passes next state once it is ready', function(done) {
+  it('passes next state once it is ready', function() {
     var render = sinon.spy()
     loop(actsCh.take, [], render)
 
@@ -46,16 +43,11 @@ describe('loop', function() {
     })
 
     assert(render.calledWith([1]))
-    assert(render.calledTwice)
-
-    setTimeout(function() {
-      assert(render.calledWith([1, 2]))
-      assert(render.calledThrice)
-      done()
-    }, 25)
+    assert(render.calledWith([1, 2]))
+    assert(render.calledThrice)
   })
 
-  it('passes previous state', function(done) {
+  it('passes previous state', function() {
     var render = sinon.spy()
     var states = []
     loop(actsCh.take, [], function(state, prevState) {
@@ -70,9 +62,6 @@ describe('loop', function() {
       return state.concat(2)
     })
 
-    setTimeout(function() {
-      assert(states[1][1] === states[0][0])
-      done()
-    }, 25)
+    assert(states[1][1] === states[0][0])
   })
 })

--- a/test.js
+++ b/test.js
@@ -16,13 +16,10 @@ describe('enso', function() {
     assert(typeof enso.act == 'function')
   })
 
-  it('wraps channel & loop', function(done) {
+  it('wraps channel & loop', function() {
     var render = sinon.spy()
     enso.loop([], render)
     enso.act(function(state) { return state.concat(1) })
-    setTimeout(function() {
-      assert(render.calledWith([1]))
-      done()
-    }, 25)
+    assert(render.calledWith([1]))
   })
 })


### PR DESCRIPTION
The next `take` should be called synchronously so actCb is always set.
Otherwise actCb can be not set on the next act which will make the next
act asynchronous (example scenario is fast typing inside controlled
React input).